### PR TITLE
Adjusted import order in __init__.py

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
-from flask import Blueprint
 """create a variable app_views which is an instance of Blueprint"""
-
-app_views = Blueprint('app_views', __name__, url_prefix='/api/v1/')
+from flask import Blueprint
 
 from api.v1.views.index import *
 from api.v1.views.states import *
@@ -12,3 +10,5 @@ from api.v1.views.users import *
 from api.v1.views.places import *
 from api.v1.views.places_reviews import *
 from api.v1.views.places_amenities import *
+
+app_views = Blueprint('app_views', __name__, url_prefix='/api/v1/')


### PR DESCRIPTION
Moved the import of modules to the top of the __init__.py file, and then defined the Blueprint object to resolve the E402 error. This change improves code organization and readability.